### PR TITLE
ehp/GH-80-fix-mocks-json-import Fix Boken Import

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,4 +7,3 @@
 <div class="sm:h-[calc(100%-70px)] sm:float-right flex flex-col items-start pl-6 py-6 gap-6 bg-[rgb(27,30,35)]/50">
     <History />
 </div>
-

--- a/src/tests/unit/mock.test.ts
+++ b/src/tests/unit/mock.test.ts
@@ -31,4 +31,11 @@ describe('Test Mock Creation', () => {
         expect(wharfAPIResponse).toHaveProperty('json');
         expect(wharfAPIResponse.json.rows.length).toBeGreaterThan(1);
     });
+    it('MockProvider returns 500 error when path does not map', async () => {
+        const mocker = new MockProvider();
+        const wharfAPIResponse = await mocker.call('/foobar');
+        expectTypeOf(wharfAPIResponse).toMatchTypeOf<APIResponse>;
+        expect(wharfAPIResponse).toHaveProperty('json');
+        expect(wharfAPIResponse.status).toBe('500');
+    });
 });


### PR DESCRIPTION
Fix build errors. Previously getting
"promisify" is not exported by "__vite-browser-external", imported by "src/tests/MockProvider.ts".

This was due to a Node module configuration change to browser context. Functions like promisify or fs.readFile and not available in a browser context. The fix uses native typescript import to pull in the JSon, and no longer performs file reads. This mocking solution will work in both node and browser contexts.
<img width="716" alt="Screenshot 2023-06-16 at 3 35 14 PM" src="https://github.com/eosnetworkfoundation/evm.faucet/assets/6685407/160dd2c5-26c6-42d2-ae96-981d7e37d8d1">
